### PR TITLE
Make SSL_VERIFYPEER configurable

### DIFF
--- a/src/python/RestClient/AuthHandling/X509Auth.py
+++ b/src/python/RestClient/AuthHandling/X509Auth.py
@@ -4,10 +4,11 @@ from RestClient.ErrorHandling.RestClientExceptions import ClientAuthException
 import os, sys
 
 class X509Auth(object):
-    def __init__(self, ca_path=None, ssl_cert=None, ssl_key=None):
+    def __init__(self, ca_path=None, ssl_cert=None, ssl_key=None, ssl_verifypeer=True):
         self._ca_path = ca_path
         self._ssl_cert = ssl_cert
         self._ssl_key = ssl_key
+        self._ssl_verifypeer = ssl_verifypeer
 
         if not (self._ssl_cert and self._ssl_key):
             self.__search_cert_key()
@@ -82,6 +83,7 @@ class X509Auth(object):
             raise ClientAuthException("No valid X509 cert-key-pair found.")
 
     def configure_auth(self, curl_object):
+        curl_object.setopt(curl_object.SSL_VERIFYPEER, self._ssl_verifypeer)
         curl_object.setopt(curl_object.CAPATH, self._ca_path)
         curl_object.setopt(curl_object.SSLCERT, self._ssl_cert)
         curl_object.setopt(curl_object.SSLKEY, self._ssl_key)


### PR DESCRIPTION
Make X509Auth to accept self-signed certificates on request. Reported by Valentin. 

"1. If you not set this option (in AuthHandling/X509Auth.py configure_auth method)
curl_object.setopt(curl_object.SSL_VERIFYPEER, False)
it can cause client to fail if does not have proper certificate, in my case I got this error
 File "/Users/vk/CMS/GIT/github/RestClient/src/python/RestClient/RequestHandling/HTTPRequest.py", line 57, in **call**
   curl_object.perform()
pycurl.error: (60, 'SSL certificate problem: self signed certificate in certificate chain')

which means that my host certficiate are self signed. Which is fine per-se, but your code should handle this use case."

Cheers,
Manuel
